### PR TITLE
feat(ui): add plugin guard

### DIFF
--- a/Mythetech.Framework.Storybook/Program.cs
+++ b/Mythetech.Framework.Storybook/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor;
 using MudBlazor.Services;
 using Mythetech.Framework.Infrastructure.MessageBus;
+using Mythetech.Framework.Infrastructure.Plugins;
 using Mythetech.Framework.WebAssembly;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -25,6 +26,8 @@ builder.Services.AddMudMarkdownServices();
 builder.Services.AddWebAssemblyServices();
 
 builder.Services.AddMessageBus();
+
+builder.Services.AddPluginFramework();
 
 var host = builder.Build();
 

--- a/Mythetech.Framework.Storybook/Stories/PluginGuard.stories.razor
+++ b/Mythetech.Framework.Storybook/Stories/PluginGuard.stories.razor
@@ -1,0 +1,203 @@
+@using Mythetech.Framework.Infrastructure.Plugins
+@using Mythetech.Framework.Infrastructure.Plugins.Components
+@using Mythetech.Framework.Storybook.Stories
+@using MudBlazor
+@attribute [Stories("Infrastructure/Plugins/PluginGuard")]
+
+<Stories TComponent="PluginGuard">
+
+    <Story Name="Enabled Plugin" Layout="typeof(DefaultMudLayout)">
+        <Template>
+            <PluginGuardStoryWrapper Scenario="PluginScenario.Enabled">
+                <MudStack Spacing="4" Style="max-width: 800px; margin: 0 auto;">
+                    <MudText Typo="Typo.h5">Plugin Guard - Enabled State</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        When a plugin is enabled, the PluginGuard renders its child content normally.
+                    </MudText>
+                    <MudPaper Class="pa-4" Elevation="2">
+                        <PluginGuard PluginInfo="@StorybookPluginData.EnabledPluginInfo" 
+                                     Metadata="@StorybookPluginData.ComponentMetadata"
+                                     ShowErrorDetails="true">
+                            <MudPaper Class="pa-4" Elevation="0" Style="background-color: var(--mud-palette-background-grey);">
+                                <MudStack Spacing="2">
+                                    <MudText Typo="Typo.h6">Sample Plugin Component</MudText>
+                                    <MudText Typo="Typo.body2">
+                                        This is the content that would normally be rendered by a DynamicComponent
+                                        wrapping a plugin component. The PluginGuard allows it to render when the plugin is enabled.
+                                    </MudText>
+                                    <MudChip T="string" Color="Color.Success" Size="Size.Small">Plugin Active</MudChip>
+                                </MudStack>
+                            </MudPaper>
+                        </PluginGuard>
+                    </MudPaper>
+                </MudStack>
+            </PluginGuardStoryWrapper>
+        </Template>
+    </Story>
+
+    <Story Name="Disabled Plugin" Layout="typeof(DefaultMudLayout)">
+        <Template>
+            <PluginGuardStoryWrapper Scenario="PluginScenario.Disabled">
+                <MudStack Spacing="4" Style="max-width: 800px; margin: 0 auto;">
+                    <MudText Typo="Typo.h5">Plugin Guard - Disabled State</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        When a plugin is disabled, the PluginGuard shows a disabled message instead of the child content.
+                    </MudText>
+                    <MudPaper Class="pa-4" Elevation="2">
+                        <PluginGuard PluginInfo="@StorybookPluginData.DisabledPluginInfo" 
+                                     Metadata="@StorybookPluginData.ComponentMetadata"
+                                     ShowErrorDetails="true">
+                            <MudText>This content should not be visible when the plugin is disabled.</MudText>
+                        </PluginGuard>
+                    </MudPaper>
+                </MudStack>
+            </PluginGuardStoryWrapper>
+        </Template>
+    </Story>
+
+    <Story Name="Deleted Plugin" Layout="typeof(DefaultMudLayout)">
+        <Template>
+            <PluginGuardStoryWrapper Scenario="PluginScenario.Deleted">
+                <MudStack Spacing="4" Style="max-width: 800px; margin: 0 auto;">
+                    <MudText Typo="Typo.h5">Plugin Guard - Deleted State</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        When a plugin is deleted (removed from PluginState), the PluginGuard shows a deleted message.
+                    </MudText>
+                    <MudPaper Class="pa-4" Elevation="2">
+                        <PluginGuard PluginInfo="@StorybookPluginData.DeletedPluginInfo" 
+                                     Metadata="@StorybookPluginData.ComponentMetadata"
+                                     ShowErrorDetails="true">
+                            <MudText>This content should not be visible when the plugin is deleted.</MudText>
+                        </PluginGuard>
+                    </MudPaper>
+                </MudStack>
+            </PluginGuardStoryWrapper>
+        </Template>
+    </Story>
+
+    <Story Name="Error State (No Details)" Layout="typeof(DefaultMudLayout)">
+        <Template>
+            <PluginGuardStoryWrapper Scenario="PluginScenario.Enabled">
+                <MudStack Spacing="4" Style="max-width: 800px; margin: 0 auto;">
+                    <MudText Typo="Typo.h5">Plugin Guard - Error State (Production)</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        When a plugin component throws an error, the PluginGuard shows an error message with plugin information.
+                        In production (ShowErrorDetails=false), detailed error information is hidden.
+                    </MudText>
+                    <MudPaper Class="pa-4" Elevation="2">
+                        <PluginGuard PluginInfo="@StorybookPluginData.EnabledPluginInfo" 
+                                     Metadata="@StorybookPluginData.ComponentMetadata"
+                                     ShowErrorDetails="false">
+                            <ThrowingComponent />
+                        </PluginGuard>
+                    </MudPaper>
+                </MudStack>
+            </PluginGuardStoryWrapper>
+        </Template>
+    </Story>
+
+    <Story Name="Error State (With Details)" Layout="typeof(DefaultMudLayout)">
+        <Template>
+            <PluginGuardStoryWrapper Scenario="PluginScenario.Enabled">
+                <MudStack Spacing="4" Style="max-width: 800px; margin: 0 auto;">
+                    <MudText Typo="Typo.h5">Plugin Guard - Error State (Development)</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        In development (ShowErrorDetails=true), the PluginGuard shows detailed error information including
+                        the error message and stack trace to help with debugging.
+                    </MudText>
+                    <MudPaper Class="pa-4" Elevation="2">
+                        <PluginGuard PluginInfo="@StorybookPluginData.EnabledPluginInfo" 
+                                     Metadata="@StorybookPluginData.ComponentMetadata"
+                                     ShowErrorDetails="true">
+                            <ThrowingComponent />
+                        </PluginGuard>
+                    </MudPaper>
+                </MudStack>
+            </PluginGuardStoryWrapper>
+        </Template>
+    </Story>
+
+    <Story Name="Interactive State Changes" Layout="typeof(DefaultMudLayout)">
+        <Template>
+            <MudStack Spacing="4" Style="max-width: 800px; margin: 0 auto;">
+                <MudText Typo="Typo.h5">Plugin Guard - Interactive State Changes</MudText>
+                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    The PluginGuard automatically updates when the plugin state changes. Use the buttons below to change the state.
+                </MudText>
+                <MudPaper Class="pa-4" Elevation="2">
+                    <MudStack Spacing="3">
+                        <MudButtonGroup Variant="Variant.Outlined" Color="Color.Primary">
+                            <MudButton OnClick="EnablePlugin">Enable Plugin</MudButton>
+                            <MudButton OnClick="DisablePlugin">Disable Plugin</MudButton>
+                            <MudButton OnClick="DeletePlugin" Color="Color.Error">Delete Plugin</MudButton>
+                            <MudButton OnClick="RestorePlugin" Color="Color.Success">Restore Plugin</MudButton>
+                        </MudButtonGroup>
+                        
+                        <MudDivider />
+                        
+                        <PluginGuard PluginInfo="@_currentPluginInfo" 
+                                     Metadata="@StorybookPluginData.ComponentMetadata"
+                                     ShowErrorDetails="true">
+                            <MudPaper Class="pa-4" Elevation="0" Style="background-color: var(--mud-palette-background-grey);">
+                                <MudStack Spacing="2">
+                                    <MudText Typo="Typo.h6">Sample Plugin Component</MudText>
+                                    <MudText Typo="Typo.body2">
+                                        This content is visible when the plugin is enabled.
+                                    </MudText>
+                                    <MudChip T="string" Color="Color.Success" Size="Size.Small">Plugin Active</MudChip>
+                                </MudStack>
+                            </MudPaper>
+                        </PluginGuard>
+                    </MudStack>
+                </MudPaper>
+            </MudStack>
+        </Template>
+    </Story>
+</Stories>
+
+@code {
+    [Inject]
+    protected PluginState PluginState { get; set; } = default!;
+    
+    private PluginInfo _currentPluginInfo = StorybookPluginData.EnabledPluginInfo;
+    
+    protected override void OnInitialized()
+    {
+        if (PluginState.GetPlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id) is null)
+        {
+            PluginState.RegisterPlugin(StorybookPluginData.EnabledPluginInfo);
+        }
+        _currentPluginInfo = StorybookPluginData.EnabledPluginInfo;
+    }
+    
+    private void EnablePlugin()
+    {
+        PluginState.EnablePlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id);
+        _currentPluginInfo = PluginState.GetPlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id)!;
+        StateHasChanged();
+    }
+    
+    private void DisablePlugin()
+    {
+        PluginState.DisablePlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id);
+        _currentPluginInfo = PluginState.GetPlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id)!;
+        StateHasChanged();
+    }
+    
+    private void DeletePlugin()
+    {
+        PluginState.RemovePlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id);
+        StateHasChanged();
+    }
+    
+    private void RestorePlugin()
+    {
+        if (PluginState.GetPlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id) is null)
+        {
+            PluginState.RegisterPlugin(StorybookPluginData.EnabledPluginInfo);
+        }
+        _currentPluginInfo = StorybookPluginData.EnabledPluginInfo;
+        StateHasChanged();
+    }
+}
+

--- a/Mythetech.Framework.Storybook/Stories/PluginGuardStoryWrapper.razor
+++ b/Mythetech.Framework.Storybook/Stories/PluginGuardStoryWrapper.razor
@@ -1,0 +1,46 @@
+@using Mythetech.Framework.Infrastructure.Plugins
+@using Mythetech.Framework.Storybook.Stories
+@using Microsoft.AspNetCore.Components
+
+@ChildContent
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+    
+    [Parameter]
+    public PluginScenario Scenario { get; set; }
+    
+    [Inject]
+    protected PluginState PluginState { get; set; } = default!;
+    
+    protected override void OnInitialized()
+    {
+        var pluginId = StorybookPluginData.EnabledPluginInfo.Manifest.Id;
+        var existingPlugin = PluginState.GetPlugin(pluginId);
+        
+        if (existingPlugin is not null)
+        {
+            PluginState.RemovePlugin(pluginId);
+        }
+        
+        switch (Scenario)
+        {
+            case PluginScenario.Enabled:
+                var enabledPlugin = StorybookPluginData.EnabledPluginInfo;
+                PluginState.RegisterPlugin(enabledPlugin);
+                PluginState.EnablePlugin(pluginId);
+                break;
+                
+            case PluginScenario.Disabled:
+                var disabledPlugin = StorybookPluginData.DisabledPluginInfo;
+                PluginState.RegisterPlugin(disabledPlugin);
+                PluginState.DisablePlugin(pluginId);
+                break;
+                
+            case PluginScenario.Deleted:
+                break;
+        }
+    }
+}
+

--- a/Mythetech.Framework.Storybook/Stories/StorybookPluginData.cs
+++ b/Mythetech.Framework.Storybook/Stories/StorybookPluginData.cs
@@ -1,0 +1,77 @@
+using System.Reflection;
+using MudBlazor;
+using Mythetech.Framework.Infrastructure.Plugins;
+
+namespace Mythetech.Framework.Storybook.Stories;
+
+/// <summary>
+/// Static data for Storybook demonstrations of PluginGuard.
+/// Provides fake plugin manifests and metadata for testing different states.
+/// </summary>
+public static class StorybookPluginData
+{
+    private static readonly IPluginManifest _manifest = new FakePluginManifest
+    {
+        Id = "storybook.demo.plugin",
+        Name = "Demo Plugin",
+        Version = new Version(2, 5, 1),
+        Developer = "Storybook Team",
+        Description = "A demonstration plugin for Storybook examples"
+    };
+    
+    private static readonly Assembly _assembly = typeof(StorybookPluginData).Assembly;
+    
+    public static readonly PluginInfo EnabledPluginInfo = new PluginInfo
+    {
+        Manifest = _manifest,
+        Assembly = _assembly,
+        IsEnabled = true,
+        LoadedAt = DateTime.UtcNow.AddDays(-5)
+    };
+    
+    public static readonly PluginInfo DisabledPluginInfo = new PluginInfo
+    {
+        Manifest = _manifest,
+        Assembly = _assembly,
+        IsEnabled = false,
+        LoadedAt = DateTime.UtcNow.AddDays(-5)
+    };
+    
+    public static readonly PluginInfo DeletedPluginInfo = new PluginInfo
+    {
+        Manifest = _manifest,
+        Assembly = _assembly,
+        IsEnabled = true,
+        LoadedAt = DateTime.UtcNow.AddDays(-5)
+    };
+    
+    public static readonly PluginComponentMetadata ComponentMetadata = new PluginComponentMetadata
+    {
+        ComponentType = typeof(StorybookPluginData),
+        Title = "Demo Component",
+        Icon = Icons.Material.Filled.Extension,
+        Order = 1,
+        Tooltip = "A demonstration plugin component"
+    };
+    
+    private class FakePluginManifest : IPluginManifest
+    {
+        public required string Id { get; init; }
+        public required string Name { get; init; }
+        public required Version Version { get; init; }
+        public required string Developer { get; init; }
+        public required string Description { get; init; }
+        public string? Icon => Icons.Material.Filled.Extension;
+        public string? ProjectUrl => "https://github.com/mythetech/Mythetech.Framework";
+        public Version? MinimumFrameworkVersion => new Version(10, 0, 0);
+        public PluginAsset[] Assets => [];
+    }
+}
+
+public enum PluginScenario
+{
+    Enabled,
+    Disabled,
+    Deleted
+}
+

--- a/Mythetech.Framework.Storybook/Stories/ThrowingComponent.razor
+++ b/Mythetech.Framework.Storybook/Stories/ThrowingComponent.razor
@@ -1,0 +1,9 @@
+@using Microsoft.AspNetCore.Components
+
+@code {
+    protected override void OnInitialized()
+    {
+        throw new InvalidOperationException("This is a test exception to demonstrate error handling in PluginGuard. The error boundary will catch this and display it appropriately.");
+    }
+}
+

--- a/Mythetech.Framework.Test/Infrastructure/Plugins/PluginGuardTests.cs
+++ b/Mythetech.Framework.Test/Infrastructure/Plugins/PluginGuardTests.cs
@@ -1,0 +1,290 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using Mythetech.Framework.Infrastructure.Plugins;
+using Mythetech.Framework.Infrastructure.Plugins.Components;
+using NSubstitute;
+using Shouldly;
+using System.Reflection;
+
+namespace Mythetech.Framework.Test.Infrastructure.Plugins;
+
+public class PluginGuardTests : TestContext
+{
+    private readonly PluginState _pluginState;
+    private IPluginManifest _manifest;
+
+    public PluginGuardTests()
+    {
+        Services.AddMudServices();
+        _pluginState = new PluginState();
+        Services.AddSingleton<PluginState>(_pluginState);
+        
+        _manifest = Substitute.For<IPluginManifest>();
+        _manifest.Id.Returns("test.plugin");
+        _manifest.Name.Returns("Test Plugin");
+        _manifest.Version.Returns(new Version(1, 2, 3));
+        _manifest.Developer.Returns("Test Developer");
+        _manifest.Description.Returns("Test Description");
+    }
+
+    private PluginInfo CreatePluginInfo(bool enabled = true)
+    {
+        return new PluginInfo
+        {
+            Manifest = _manifest,
+            Assembly = typeof(PluginGuardTests).Assembly,
+            IsEnabled = enabled
+        };
+    }
+
+    private PluginComponentMetadata CreateMetadata()
+    {
+        return new PluginComponentMetadata
+        {
+            ComponentType = typeof(TestComponent),
+            Title = "Test Component",
+            Icon = Icons.Material.Filled.Extension,
+            Order = 1
+        };
+    }
+
+    [Fact(DisplayName = "Renders child content when plugin is enabled")]
+    public void Renders_ChildContent_When_Plugin_Enabled()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: true);
+        _pluginState.RegisterPlugin(pluginInfo);
+        var metadata = CreateMetadata();
+
+        // Act
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .AddChildContent("<div class=\"test-content\">Hello World</div>"));
+
+        // Assert
+        cut.Find(".test-content").TextContent.ShouldBe("Hello World");
+    }
+
+    [Fact(DisplayName = "Shows disabled UI when plugin is disabled")]
+    public void Shows_DisabledUI_When_Plugin_Disabled()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: false);
+        _pluginState.RegisterPlugin(pluginInfo);
+        var metadata = CreateMetadata();
+
+        // Act
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .AddChildContent("<div class=\"test-content\">Should not render</div>"));
+
+        // Assert
+        cut.Markup.ShouldContain("Plugin Disabled");
+        cut.Markup.ShouldContain("Test Plugin");
+        cut.Markup.ShouldContain("1.2.3");
+        cut.FindAll(".test-content").Count.ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Shows disabled UI when PluginsActive is false")]
+    public void Shows_DisabledUI_When_PluginsActive_False()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: true);
+        _pluginState.RegisterPlugin(pluginInfo);
+        _pluginState.PluginsActive = false;
+        var metadata = CreateMetadata();
+
+        // Act
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .AddChildContent("<div class=\"test-content\">Should not render</div>"));
+
+        // Assert
+        cut.Markup.ShouldContain("Plugin Disabled");
+        cut.FindAll(".test-content").Count.ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Shows deleted UI when plugin is removed")]
+    public void Shows_DeletedUI_When_Plugin_Removed()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: true);
+        _pluginState.RegisterPlugin(pluginInfo);
+        var metadata = CreateMetadata();
+
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .AddChildContent("<div class=\"test-content\">Should not render</div>"));
+
+        // Act - Remove the plugin
+        _pluginState.RemovePlugin(pluginInfo.Manifest.Id);
+        cut.Render();
+
+        // Assert
+        cut.Markup.ShouldContain("Plugin Deleted");
+        cut.Markup.ShouldContain("Test Plugin");
+        cut.FindAll(".test-content").Count.ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Shows error UI when child component throws exception")]
+    public void Shows_ErrorUI_When_Component_Throws()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: true);
+        _pluginState.RegisterPlugin(pluginInfo);
+        var metadata = CreateMetadata();
+
+        // Act
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .AddChildContent<ThrowingComponent>());
+
+        // Assert
+        cut.Markup.ShouldContain("Plugin Error");
+        cut.Markup.ShouldContain("Test Plugin");
+        cut.Markup.ShouldContain("1.2.3");
+        cut.Markup.ShouldContain("Test Component");
+    }
+
+    [Fact(DisplayName = "Shows error details when ShowErrorDetails is true")]
+    public void Shows_ErrorDetails_When_ShowErrorDetails_True()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: true);
+        _pluginState.RegisterPlugin(pluginInfo);
+        var metadata = CreateMetadata();
+
+        // Act
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .Add(p => p.ShowErrorDetails, true)
+            .AddChildContent<ThrowingComponent>());
+
+        // Assert
+        cut.Markup.ShouldContain("Error Details");
+        cut.Markup.ShouldContain("Test exception");
+    }
+
+    [Fact(DisplayName = "Hides error details when ShowErrorDetails is false")]
+    public void Hides_ErrorDetails_When_ShowErrorDetails_False()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: true);
+        _pluginState.RegisterPlugin(pluginInfo);
+        var metadata = CreateMetadata();
+
+        // Act
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .Add(p => p.ShowErrorDetails, false)
+            .AddChildContent<ThrowingComponent>());
+
+        // Assert
+        cut.Markup.ShouldNotContain("Error Details");
+    }
+
+    [Fact(DisplayName = "Updates UI when plugin state changes from enabled to disabled")]
+    public void Updates_UI_When_Plugin_Disabled()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: true);
+        _pluginState.RegisterPlugin(pluginInfo);
+        var metadata = CreateMetadata();
+
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .AddChildContent("<div class=\"test-content\">Hello</div>"));
+
+        cut.Find(".test-content").ShouldNotBeNull();
+
+        // Act - Disable the plugin
+        _pluginState.DisablePlugin(pluginInfo.Manifest.Id);
+        cut.Render();
+
+        // Assert
+        cut.Markup.ShouldContain("Plugin Disabled");
+        cut.FindAll(".test-content").Count.ShouldBe(0);
+    }
+
+    [Fact(DisplayName = "Updates UI when plugin state changes from disabled to enabled")]
+    public void Updates_UI_When_Plugin_Enabled()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: false);
+        _pluginState.RegisterPlugin(pluginInfo);
+        var metadata = CreateMetadata();
+
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .AddChildContent("<div class=\"test-content\">Hello</div>"));
+
+        cut.Markup.ShouldContain("Plugin Disabled");
+
+        // Act - Enable the plugin
+        _pluginState.EnablePlugin(pluginInfo.Manifest.Id);
+        cut.Render();
+
+        // Assert
+        cut.Find(".test-content").TextContent.ShouldBe("Hello");
+        cut.Markup.ShouldNotContain("Plugin Disabled");
+    }
+
+    [Fact(DisplayName = "Updates UI when PluginsActive changes")]
+    public void Updates_UI_When_PluginsActive_Changes()
+    {
+        // Arrange
+        var pluginInfo = CreatePluginInfo(enabled: true);
+        _pluginState.RegisterPlugin(pluginInfo);
+        var metadata = CreateMetadata();
+
+        var cut = RenderComponent<PluginGuard>(parameters => parameters
+            .Add(p => p.PluginInfo, pluginInfo)
+            .Add(p => p.Metadata, metadata)
+            .AddChildContent("<div class=\"test-content\">Hello</div>"));
+
+        cut.Find(".test-content").ShouldNotBeNull();
+
+        // Act - Disable all plugins
+        _pluginState.PluginsActive = false;
+        cut.Render();
+
+        // Assert
+        cut.Markup.ShouldContain("Plugin Disabled");
+        cut.FindAll(".test-content").Count.ShouldBe(0);
+    }
+}
+
+#region Test Components
+
+internal class TestComponent : Microsoft.AspNetCore.Components.ComponentBase
+{
+    protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", "test-component");
+        builder.AddContent(2, "Test Component Content");
+        builder.CloseElement();
+    }
+}
+
+internal class ThrowingComponent : Microsoft.AspNetCore.Components.ComponentBase
+{
+    protected override void OnInitialized()
+    {
+        throw new Exception("Test exception");
+    }
+}
+
+#endregion
+

--- a/Mythetech.Framework/Infrastructure/Plugins/Components/PluginGuard.razor
+++ b/Mythetech.Framework/Infrastructure/Plugins/Components/PluginGuard.razor
@@ -1,0 +1,158 @@
+@using MudBlazor
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@inject PluginState PluginState
+@implements IDisposable
+
+<ErrorBoundary @ref="_errorBoundary">
+    <ChildContent>
+        @if (IsPluginDeleted)
+        {
+            <MudPaper Class="pa-4" Elevation="1">
+                <MudStack Spacing="3" AlignItems="AlignItems.Center">
+                    <MudIcon Icon="@Icons.Material.Filled.Delete" Size="Size.Large" Color="Color.Error" />
+                    <MudText Typo="Typo.h6">Plugin Deleted</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        The plugin "@PluginInfo.Manifest.Name" has been deleted and is no longer available.
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+        }
+        else if (IsPluginDisabled)
+        {
+            <MudPaper Class="pa-4" Elevation="1">
+                <MudStack Spacing="3" AlignItems="AlignItems.Center">
+                    <MudIcon Icon="@Icons.Material.Filled.Block" Size="Size.Large" Color="Color.Warning" />
+                    <MudText Typo="Typo.h6">Plugin Disabled</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        The plugin "@PluginInfo.Manifest.Name" is currently disabled.
+                    </MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                        Version @PluginInfo.Manifest.Version
+                    </MudText>
+                </MudStack>
+            </MudPaper>
+        }
+        else
+        {
+            @ChildContent
+        }
+    </ChildContent>
+    <ErrorContent Context="errorContext">
+        <MudPaper Class="pa-4" Elevation="1">
+            <MudStack Spacing="3">
+                <MudStack Row Spacing="2" AlignItems="AlignItems.Center">
+                    <MudIcon Icon="@Icons.Material.Filled.Error" Size="Size.Large" Color="Color.Error" />
+                    <MudText Typo="Typo.h6" Color="Color.Error">Plugin Error</MudText>
+                </MudStack>
+                
+                <MudText Typo="Typo.body1">
+                    An error occurred while rendering the plugin component.
+                </MudText>
+                
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.body2">
+                        <strong>Plugin:</strong> @PluginInfo.Manifest.Name
+                    </MudText>
+                    <MudText Typo="Typo.body2">
+                        <strong>Version:</strong> @PluginInfo.Manifest.Version
+                    </MudText>
+                    <MudText Typo="Typo.body2">
+                        <strong>Component:</strong> @Metadata.Title
+                    </MudText>
+                </MudStack>
+                
+                @if (ShowErrorDetails)
+                {
+                    <MudDivider Class="my-3" />
+                    <MudText Typo="Typo.subtitle2" Class="mb-2">Error Details:</MudText>
+                    <MudPaper Class="pa-3" Elevation="0" Style="background-color: var(--mud-palette-dark-darkenen); max-height: 300px; overflow: auto;">
+                        <MudText Typo="Typo.body2" Color="Color.Error" Class="mb-2">@errorContext.Message</MudText>
+                        @if (!string.IsNullOrWhiteSpace(errorContext.StackTrace))
+                        {
+                            <pre style="margin: 0; font-size: 0.75rem; color: var(--mud-palette-text-secondary); white-space: pre-wrap; word-wrap: break-word;">@errorContext.StackTrace</pre>
+                        }
+                    </MudPaper>
+                }
+            </MudStack>
+        </MudPaper>
+    </ErrorContent>
+</ErrorBoundary>
+
+@code {
+    private ErrorBoundary? _errorBoundary;
+    
+    /// <summary>
+    /// The plugin information for the plugin being guarded
+    /// </summary>
+    [Parameter, EditorRequired]
+    public PluginInfo PluginInfo { get; set; } = null!;
+    
+    /// <summary>
+    /// The component metadata for the specific component being guarded
+    /// </summary>
+    [Parameter, EditorRequired]
+    public PluginComponentMetadata Metadata { get; set; } = null!;
+    
+    /// <summary>
+    /// Child content to render when the plugin is enabled and not deleted
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+    
+    /// <summary>
+    /// Whether to show detailed error information (stack traces, etc.). 
+    /// Should be true in development environments.
+    /// </summary>
+    [Parameter]
+    public bool ShowErrorDetails { get; set; }
+    
+    /// <summary>
+    /// Whether the plugin is currently deleted (removed from PluginState)
+    /// </summary>
+    private bool IsPluginDeleted => PluginState.GetPlugin(PluginInfo.Manifest.Id) is null;
+    
+    /// <summary>
+    /// Whether the plugin is currently disabled
+    /// </summary>
+    private bool IsPluginDisabled
+    {
+        get
+        {
+            if (!PluginState.PluginsActive) return true;
+            var plugin = PluginState.GetPlugin(PluginInfo.Manifest.Id);
+            return plugin is null || !plugin.IsEnabled;
+        }
+    }
+    
+    protected override void OnInitialized()
+    {
+        PluginState.StateChanged += OnStateChanged;
+    }
+    
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender && _errorBoundary is not null)
+        {
+            _errorBoundary.Recover();
+        }
+    }
+    
+    private void OnStateChanged(object? sender, EventArgs e)
+    {
+        InvokeAsync(() =>
+        {
+            StateHasChanged();
+            if (_errorBoundary is not null)
+            {
+                _errorBoundary.Recover();
+            }
+        });
+    }
+    
+    public void Dispose()
+    {
+        PluginState.StateChanged -= OnStateChanged;
+    }
+}
+

--- a/Mythetech.Framework/Mythetech.Framework.csproj
+++ b/Mythetech.Framework/Mythetech.Framework.csproj
@@ -7,7 +7,7 @@
         <Company>Mythetech</Company>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <PackageId>Mythetech.Framework</PackageId>
-        <Version>0.1.13</Version>
+        <Version>0.1.14</Version>
         <Authors>Mythetech</Authors>
         <Description>Base component library for Mythetech applications</Description>
         <PackageTags>blazor;components;ui</PackageTags>


### PR DESCRIPTION
Gives a convenient wrapper for an error boundary with different states of plugin lifecycle with proper state handling