### PR TITLE
feat: improve plugin initilization api

### DIFF
--- a/Mythetech.Framework.Storybook/Program.cs
+++ b/Mythetech.Framework.Storybook/Program.cs
@@ -36,6 +36,6 @@ var host = builder.Build();
 
 host.Services.UseMessageBus();
 
-host.Services.UsePlugins();
+await host.Services.UsePluginsAsync();
 
 await host.RunAsync();

--- a/Mythetech.Framework.Storybook/Stories/PluginGuard.stories.razor
+++ b/Mythetech.Framework.Storybook/Stories/PluginGuard.stories.razor
@@ -158,43 +158,43 @@
 @code {
     [Inject]
     protected PluginState PluginState { get; set; } = default!;
-    
+
     private PluginInfo _currentPluginInfo = StorybookPluginData.EnabledPluginInfo;
-    
-    protected override void OnInitialized()
+
+    protected override async Task OnInitializedAsync()
     {
         if (PluginState.GetPlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id) is null)
         {
-            PluginState.RegisterPlugin(StorybookPluginData.EnabledPluginInfo);
+            await PluginState.RegisterPluginAsync(StorybookPluginData.EnabledPluginInfo);
         }
         _currentPluginInfo = StorybookPluginData.EnabledPluginInfo;
     }
-    
-    private void EnablePlugin()
+
+    private async Task EnablePlugin()
     {
-        PluginState.EnablePlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id);
+        await PluginState.EnablePluginAsync(StorybookPluginData.EnabledPluginInfo.Manifest.Id);
         _currentPluginInfo = PluginState.GetPlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id)!;
         StateHasChanged();
     }
-    
-    private void DisablePlugin()
+
+    private async Task DisablePlugin()
     {
-        PluginState.DisablePlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id);
+        await PluginState.DisablePluginAsync(StorybookPluginData.EnabledPluginInfo.Manifest.Id);
         _currentPluginInfo = PluginState.GetPlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id)!;
         StateHasChanged();
     }
-    
-    private void DeletePlugin()
+
+    private async Task DeletePlugin()
     {
-        PluginState.RemovePlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id);
+        await PluginState.RemovePluginAsync(StorybookPluginData.EnabledPluginInfo.Manifest.Id);
         StateHasChanged();
     }
-    
-    private void RestorePlugin()
+
+    private async Task RestorePlugin()
     {
         if (PluginState.GetPlugin(StorybookPluginData.EnabledPluginInfo.Manifest.Id) is null)
         {
-            PluginState.RegisterPlugin(StorybookPluginData.EnabledPluginInfo);
+            await PluginState.RegisterPluginAsync(StorybookPluginData.EnabledPluginInfo);
         }
         _currentPluginInfo = StorybookPluginData.EnabledPluginInfo;
         StateHasChanged();

--- a/Mythetech.Framework.Storybook/Stories/PluginGuardStoryWrapper.razor
+++ b/Mythetech.Framework.Storybook/Stories/PluginGuardStoryWrapper.razor
@@ -7,37 +7,37 @@
 @code {
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
-    
+
     [Parameter]
     public PluginScenario Scenario { get; set; }
-    
+
     [Inject]
     protected PluginState PluginState { get; set; } = default!;
-    
-    protected override void OnInitialized()
+
+    protected override async Task OnInitializedAsync()
     {
         var pluginId = StorybookPluginData.EnabledPluginInfo.Manifest.Id;
         var existingPlugin = PluginState.GetPlugin(pluginId);
-        
+
         if (existingPlugin is not null)
         {
-            PluginState.RemovePlugin(pluginId);
+            await PluginState.RemovePluginAsync(pluginId);
         }
-        
+
         switch (Scenario)
         {
             case PluginScenario.Enabled:
                 var enabledPlugin = StorybookPluginData.EnabledPluginInfo;
-                PluginState.RegisterPlugin(enabledPlugin);
-                PluginState.EnablePlugin(pluginId);
+                await PluginState.RegisterPluginAsync(enabledPlugin);
+                await PluginState.EnablePluginAsync(pluginId);
                 break;
-                
+
             case PluginScenario.Disabled:
                 var disabledPlugin = StorybookPluginData.DisabledPluginInfo;
-                PluginState.RegisterPlugin(disabledPlugin);
-                PluginState.DisablePlugin(pluginId);
+                await PluginState.RegisterPluginAsync(disabledPlugin);
+                await PluginState.DisablePluginAsync(pluginId);
                 break;
-                
+
             case PluginScenario.Deleted:
                 break;
         }

--- a/Mythetech.Framework.Test/Infrastructure/Plugins/DisabledPluginConsumerFilterTests.cs
+++ b/Mythetech.Framework.Test/Infrastructure/Plugins/DisabledPluginConsumerFilterTests.cs
@@ -31,56 +31,56 @@ public class DisabledPluginConsumerFilterTests
     }
 
     [Fact(DisplayName = "Consumer from enabled plugin is allowed")]
-    public void ConsumerFromEnabledPlugin_IsAllowed()
+    public async Task ConsumerFromEnabledPlugin_IsAllowed()
     {
         // Arrange
         var assembly = typeof(TestConsumer).Assembly;
         var pluginInfo = CreatePluginInfo("test-plugin", assembly, isEnabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
-        
+        await _pluginState.RegisterPluginAsync(pluginInfo);
+
         var consumer = new TestConsumer();
         var message = new TestMessage("Test");
-        
+
         // Act
         var result = _filter.ShouldInvoke(consumer, message);
-        
+
         // Assert
         result.ShouldBeTrue();
     }
 
     [Fact(DisplayName = "Consumer from disabled plugin is blocked")]
-    public void ConsumerFromDisabledPlugin_IsBlocked()
+    public async Task ConsumerFromDisabledPlugin_IsBlocked()
     {
         // Arrange
         var assembly = typeof(TestConsumer).Assembly;
         var pluginInfo = CreatePluginInfo("test-plugin", assembly, isEnabled: false);
-        _pluginState.RegisterPlugin(pluginInfo);
-        
+        await _pluginState.RegisterPluginAsync(pluginInfo);
+
         var consumer = new TestConsumer();
         var message = new TestMessage("Test");
-        
+
         // Act
         var result = _filter.ShouldInvoke(consumer, message);
-        
+
         // Assert
         result.ShouldBeFalse();
     }
 
     [Fact(DisplayName = "Consumer from plugin is blocked when PluginsActive is false")]
-    public void ConsumerFromPlugin_BlockedWhenPluginsInactive()
+    public async Task ConsumerFromPlugin_BlockedWhenPluginsInactive()
     {
         // Arrange
         var assembly = typeof(TestConsumer).Assembly;
         var pluginInfo = CreatePluginInfo("test-plugin", assembly, isEnabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         _pluginState.PluginsActive = false;
-        
+
         var consumer = new TestConsumer();
         var message = new TestMessage("Test");
-        
+
         // Act
         var result = _filter.ShouldInvoke(consumer, message);
-        
+
         // Assert
         result.ShouldBeFalse();
     }

--- a/Mythetech.Framework.Test/Infrastructure/Plugins/PluginBoundaryTests.cs
+++ b/Mythetech.Framework.Test/Infrastructure/Plugins/PluginBoundaryTests.cs
@@ -19,57 +19,57 @@ public class PluginBoundaryTests
     #region PluginStateStore Isolation Tests
 
     [Fact(DisplayName = "State set by Plugin A is not visible to Plugin B")]
-    public void StateStore_PluginA_NotVisibleTo_PluginB()
+    public async Task StateStore_PluginA_NotVisibleTo_PluginB()
     {
         // Arrange
         var pluginA = CreateMockPlugin("plugin.a", typeof(PluginAType).Assembly);
         var pluginB = CreateMockPlugin("plugin.b", typeof(PluginBType).Assembly);
-        _pluginState.RegisterPlugin(pluginA);
-        _pluginState.RegisterPlugin(pluginB);
-        
+        await _pluginState.RegisterPluginAsync(pluginA);
+        await _pluginState.RegisterPluginAsync(pluginB);
+
         // Act - Plugin A sets state
         _stateStore.Set("plugin.a", "counter", 42);
-        
+
         // Assert - Plugin A can read it
         _stateStore.Get<int>("plugin.a", "counter").ShouldBe(42);
-        
+
         // Assert - Plugin B cannot see Plugin A's state
         _stateStore.Get<int>("plugin.b", "counter").ShouldBe(0); // default int
     }
 
     [Fact(DisplayName = "Plugins can use the same key names without conflict")]
-    public void StateStore_SameKeyNames_NoConflict()
+    public async Task StateStore_SameKeyNames_NoConflict()
     {
         // Arrange
         var pluginA = CreateMockPlugin("plugin.a", typeof(PluginAType).Assembly);
         var pluginB = CreateMockPlugin("plugin.b", typeof(PluginBType).Assembly);
-        _pluginState.RegisterPlugin(pluginA);
-        _pluginState.RegisterPlugin(pluginB);
-        
+        await _pluginState.RegisterPluginAsync(pluginA);
+        await _pluginState.RegisterPluginAsync(pluginB);
+
         // Act - Both plugins set "settings" key
         _stateStore.Set("plugin.a", "settings", "A's settings");
         _stateStore.Set("plugin.b", "settings", "B's settings");
-        
+
         // Assert - Each plugin sees its own value
         _stateStore.Get<string>("plugin.a", "settings").ShouldBe("A's settings");
         _stateStore.Get<string>("plugin.b", "settings").ShouldBe("B's settings");
     }
 
     [Fact(DisplayName = "Clearing one plugin's state doesn't affect another")]
-    public void StateStore_ClearPlugin_DoesNotAffectOthers()
+    public async Task StateStore_ClearPlugin_DoesNotAffectOthers()
     {
         // Arrange
         var pluginA = CreateMockPlugin("plugin.a", typeof(PluginAType).Assembly);
         var pluginB = CreateMockPlugin("plugin.b", typeof(PluginBType).Assembly);
-        _pluginState.RegisterPlugin(pluginA);
-        _pluginState.RegisterPlugin(pluginB);
-        
+        await _pluginState.RegisterPluginAsync(pluginA);
+        await _pluginState.RegisterPluginAsync(pluginB);
+
         _stateStore.Set("plugin.a", "data", "A's data");
         _stateStore.Set("plugin.b", "data", "B's data");
-        
+
         // Act - Clear Plugin A's state
         _stateStore.ClearPlugin("plugin.a");
-        
+
         // Assert
         _stateStore.Get<string>("plugin.a", "data").ShouldBeNull();
         _stateStore.Get<string>("plugin.b", "data").ShouldBe("B's data");
@@ -96,32 +96,32 @@ public class PluginBoundaryTests
     }
 
     [Fact(DisplayName = "GetForPlugin uses assembly to infer plugin ID")]
-    public void StateStore_GetForPlugin_InfersPluginId()
+    public async Task StateStore_GetForPlugin_InfersPluginId()
     {
         // Arrange
         var pluginA = CreateMockPlugin("plugin.a", typeof(PluginAType).Assembly);
-        _pluginState.RegisterPlugin(pluginA);
-        
+        await _pluginState.RegisterPluginAsync(pluginA);
+
         // Set directly by plugin ID
         _stateStore.Set("plugin.a", "value", 123);
-        
+
         // Act - Get using type (simulating component access)
         var result = _stateStore.GetForPlugin<int>(typeof(PluginAType), "value");
-        
+
         // Assert
         result.ShouldBe(123);
     }
 
     [Fact(DisplayName = "SetForPlugin uses assembly to infer plugin ID")]
-    public void StateStore_SetForPlugin_InfersPluginId()
+    public async Task StateStore_SetForPlugin_InfersPluginId()
     {
         // Arrange
         var pluginA = CreateMockPlugin("plugin.a", typeof(PluginAType).Assembly);
-        _pluginState.RegisterPlugin(pluginA);
-        
+        await _pluginState.RegisterPluginAsync(pluginA);
+
         // Act - Set using type (simulating component access)
         _stateStore.SetForPlugin(typeof(PluginAType), "value", 456);
-        
+
         // Assert - Verify via direct plugin ID access
         _stateStore.Get<int>("plugin.a", "value").ShouldBe(456);
     }
@@ -143,49 +143,49 @@ public class PluginBoundaryTests
     #region PluginState Registration Tests
 
     [Fact(DisplayName = "Cannot register plugin with duplicate ID")]
-    public void PluginState_DuplicateId_Throws()
+    public async Task PluginState_DuplicateId_Throws()
     {
         // Arrange
         var plugin1 = CreateMockPlugin("same.id", typeof(PluginAType).Assembly);
         var plugin2 = CreateMockPlugin("same.id", typeof(PluginBType).Assembly);
-        
-        _pluginState.RegisterPlugin(plugin1);
-        
+
+        await _pluginState.RegisterPluginAsync(plugin1);
+
         // Act & Assert
-        Should.Throw<InvalidOperationException>(() => _pluginState.RegisterPlugin(plugin2));
+        await Should.ThrowAsync<InvalidOperationException>(() => _pluginState.RegisterPluginAsync(plugin2));
     }
 
     [Fact(DisplayName = "Disabling plugin removes it from EnabledPlugins")]
-    public void PluginState_DisablePlugin_RemovedFromEnabled()
+    public async Task PluginState_DisablePlugin_RemovedFromEnabled()
     {
         // Arrange
         var plugin = CreateMockPlugin("test.plugin", typeof(PluginAType).Assembly);
-        _pluginState.RegisterPlugin(plugin);
-        
+        await _pluginState.RegisterPluginAsync(plugin);
+
         _pluginState.EnabledPlugins.ShouldContain(plugin);
-        
+
         // Act
-        _pluginState.DisablePlugin("test.plugin");
-        
+        await _pluginState.DisablePluginAsync("test.plugin");
+
         // Assert
         _pluginState.EnabledPlugins.ShouldNotContain(plugin);
         _pluginState.Plugins.ShouldContain(plugin); // Still in all plugins
     }
 
     [Fact(DisplayName = "PluginsActive = false disables all plugins")]
-    public void PluginState_PluginsActive_False_DisablesAll()
+    public async Task PluginState_PluginsActive_False_DisablesAll()
     {
         // Arrange
         var plugin1 = CreateMockPlugin("plugin.1", typeof(PluginAType).Assembly);
         var plugin2 = CreateMockPlugin("plugin.2", typeof(PluginBType).Assembly);
-        _pluginState.RegisterPlugin(plugin1);
-        _pluginState.RegisterPlugin(plugin2);
-        
+        await _pluginState.RegisterPluginAsync(plugin1);
+        await _pluginState.RegisterPluginAsync(plugin2);
+
         _pluginState.EnabledPlugins.Count().ShouldBe(2);
-        
+
         // Act
         _pluginState.PluginsActive = false;
-        
+
         // Assert
         _pluginState.EnabledPlugins.Count().ShouldBe(0);
         _pluginState.Plugins.Count.ShouldBe(2); // Still registered

--- a/Mythetech.Framework.Test/Infrastructure/Plugins/PluginGuardTests.cs
+++ b/Mythetech.Framework.Test/Infrastructure/Plugins/PluginGuardTests.cs
@@ -51,11 +51,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Renders child content when plugin is enabled")]
-    public void Renders_ChildContent_When_Plugin_Enabled()
+    public async Task Renders_ChildContent_When_Plugin_Enabled()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         var metadata = CreateMetadata();
 
         // Act
@@ -69,11 +69,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Shows disabled UI when plugin is disabled")]
-    public void Shows_DisabledUI_When_Plugin_Disabled()
+    public async Task Shows_DisabledUI_When_Plugin_Disabled()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: false);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         var metadata = CreateMetadata();
 
         // Act
@@ -90,11 +90,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Shows disabled UI when PluginsActive is false")]
-    public void Shows_DisabledUI_When_PluginsActive_False()
+    public async Task Shows_DisabledUI_When_PluginsActive_False()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         _pluginState.PluginsActive = false;
         var metadata = CreateMetadata();
 
@@ -110,11 +110,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Shows deleted UI when plugin is removed")]
-    public void Shows_DeletedUI_When_Plugin_Removed()
+    public async Task Shows_DeletedUI_When_Plugin_Removed()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         var metadata = CreateMetadata();
 
         var cut = RenderComponent<PluginGuard>(parameters => parameters
@@ -123,7 +123,7 @@ public class PluginGuardTests : TestContext
             .AddChildContent("<div class=\"test-content\">Should not render</div>"));
 
         // Act - Remove the plugin
-        _pluginState.RemovePlugin(pluginInfo.Manifest.Id);
+        await _pluginState.RemovePluginAsync(pluginInfo.Manifest.Id);
         cut.Render();
 
         // Assert
@@ -133,11 +133,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Shows error UI when child component throws exception")]
-    public void Shows_ErrorUI_When_Component_Throws()
+    public async Task Shows_ErrorUI_When_Component_Throws()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         var metadata = CreateMetadata();
 
         // Act
@@ -154,11 +154,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Shows error details when ShowErrorDetails is true")]
-    public void Shows_ErrorDetails_When_ShowErrorDetails_True()
+    public async Task Shows_ErrorDetails_When_ShowErrorDetails_True()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         var metadata = CreateMetadata();
 
         // Act
@@ -174,11 +174,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Hides error details when ShowErrorDetails is false")]
-    public void Hides_ErrorDetails_When_ShowErrorDetails_False()
+    public async Task Hides_ErrorDetails_When_ShowErrorDetails_False()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         var metadata = CreateMetadata();
 
         // Act
@@ -193,11 +193,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Updates UI when plugin state changes from enabled to disabled")]
-    public void Updates_UI_When_Plugin_Disabled()
+    public async Task Updates_UI_When_Plugin_Disabled()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         var metadata = CreateMetadata();
 
         var cut = RenderComponent<PluginGuard>(parameters => parameters
@@ -208,7 +208,7 @@ public class PluginGuardTests : TestContext
         cut.Find(".test-content").ShouldNotBeNull();
 
         // Act - Disable the plugin
-        _pluginState.DisablePlugin(pluginInfo.Manifest.Id);
+        await _pluginState.DisablePluginAsync(pluginInfo.Manifest.Id);
         cut.Render();
 
         // Assert
@@ -217,11 +217,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Updates UI when plugin state changes from disabled to enabled")]
-    public void Updates_UI_When_Plugin_Enabled()
+    public async Task Updates_UI_When_Plugin_Enabled()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: false);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         var metadata = CreateMetadata();
 
         var cut = RenderComponent<PluginGuard>(parameters => parameters
@@ -232,7 +232,7 @@ public class PluginGuardTests : TestContext
         cut.Markup.ShouldContain("Plugin Disabled");
 
         // Act - Enable the plugin
-        _pluginState.EnablePlugin(pluginInfo.Manifest.Id);
+        await _pluginState.EnablePluginAsync(pluginInfo.Manifest.Id);
         cut.Render();
 
         // Assert
@@ -241,11 +241,11 @@ public class PluginGuardTests : TestContext
     }
 
     [Fact(DisplayName = "Updates UI when PluginsActive changes")]
-    public void Updates_UI_When_PluginsActive_Changes()
+    public async Task Updates_UI_When_PluginsActive_Changes()
     {
         // Arrange
         var pluginInfo = CreatePluginInfo(enabled: true);
-        _pluginState.RegisterPlugin(pluginInfo);
+        await _pluginState.RegisterPluginAsync(pluginInfo);
         var metadata = CreateMetadata();
 
         var cut = RenderComponent<PluginGuard>(parameters => parameters

--- a/Mythetech.Framework/Infrastructure/MessageBus/ComponentConsumer.cs
+++ b/Mythetech.Framework/Infrastructure/MessageBus/ComponentConsumer.cs
@@ -75,8 +75,19 @@ public abstract class ComponentConsumer<T1, T2> : ComponentBase, IDisposable
         base.OnInitialized();
         _consumer1 = new Consumer1(this);
         _consumer2 = new Consumer2(this);
-        MessageBus.Subscribe(_consumer1);
-        MessageBus.Subscribe(_consumer2);
+
+        try
+        {
+            MessageBus.Subscribe(_consumer1);
+            MessageBus.Subscribe(_consumer2);
+        }
+        catch
+        {
+            // Clean up any subscribed consumers if initialization fails
+            if (_consumer1 is not null) MessageBus.Unsubscribe(_consumer1);
+            if (_consumer2 is not null) MessageBus.Unsubscribe(_consumer2);
+            throw;
+        }
     }
 
     private async Task HandleMessage1(T1 message)
@@ -150,9 +161,21 @@ public abstract class ComponentConsumer<T1, T2, T3> : ComponentBase, IDisposable
         _consumer1 = new Consumer1(this);
         _consumer2 = new Consumer2(this);
         _consumer3 = new Consumer3(this);
-        MessageBus.Subscribe(_consumer1);
-        MessageBus.Subscribe(_consumer2);
-        MessageBus.Subscribe(_consumer3);
+
+        try
+        {
+            MessageBus.Subscribe(_consumer1);
+            MessageBus.Subscribe(_consumer2);
+            MessageBus.Subscribe(_consumer3);
+        }
+        catch
+        {
+            // Clean up any subscribed consumers if initialization fails
+            if (_consumer1 is not null) MessageBus.Unsubscribe(_consumer1);
+            if (_consumer2 is not null) MessageBus.Unsubscribe(_consumer2);
+            if (_consumer3 is not null) MessageBus.Unsubscribe(_consumer3);
+            throw;
+        }
     }
 
     private async Task HandleMessage1(T1 message)
@@ -246,10 +269,23 @@ public abstract class ComponentConsumer<T1, T2, T3, T4> : ComponentBase, IDispos
         _consumer2 = new Consumer2(this);
         _consumer3 = new Consumer3(this);
         _consumer4 = new Consumer4(this);
-        MessageBus.Subscribe(_consumer1);
-        MessageBus.Subscribe(_consumer2);
-        MessageBus.Subscribe(_consumer3);
-        MessageBus.Subscribe(_consumer4);
+
+        try
+        {
+            MessageBus.Subscribe(_consumer1);
+            MessageBus.Subscribe(_consumer2);
+            MessageBus.Subscribe(_consumer3);
+            MessageBus.Subscribe(_consumer4);
+        }
+        catch
+        {
+            // Clean up any subscribed consumers if initialization fails
+            if (_consumer1 is not null) MessageBus.Unsubscribe(_consumer1);
+            if (_consumer2 is not null) MessageBus.Unsubscribe(_consumer2);
+            if (_consumer3 is not null) MessageBus.Unsubscribe(_consumer3);
+            if (_consumer4 is not null) MessageBus.Unsubscribe(_consumer4);
+            throw;
+        }
     }
 
     private async Task HandleMessage1(T1 message)

--- a/Mythetech.Framework/Infrastructure/Plugins/Components/DefaultPluginUrlLoadDialog.razor
+++ b/Mythetech.Framework/Infrastructure/Plugins/Components/DefaultPluginUrlLoadDialog.razor
@@ -181,7 +181,7 @@
             
             foreach (var plugin in loadedPlugins)
             {
-                PluginState.RegisterPlugin(plugin);
+                await PluginState.RegisterPluginAsync(plugin);
             }
             
             Snackbar.Add($"Successfully loaded {loadedPlugins.Count} plugin(s) from '{_pluginName}'", Severity.Success);

--- a/Mythetech.Framework/Infrastructure/Plugins/Components/PluginManagementDialog.razor
+++ b/Mythetech.Framework/Infrastructure/Plugins/Components/PluginManagementDialog.razor
@@ -2,6 +2,7 @@
 @using Mythetech.Framework.Components.SimpleTabs
 @using Mythetech.Framework.Components.Badge
 @using Mythetech.Framework.Components.Buttons
+@using Mythetech.Framework.Components.Switch
 @using Mythetech.Framework.Infrastructure.Environment
 @using System.IO.Compression
 @using System.Net.Http
@@ -71,12 +72,12 @@
                 </Tab>
                 <Tab Name="@_availableTabName">
                     <MudStack Row="true" Justify="Justify.FlexEnd" Class="mb-2">
-                        <MudCheckBox T="bool" Value="_showPreviewPlugins"
-                                     Label="Show preview plugins"
-                                     Size="Size.Small"
-                                     Dense="true"
-                                     Color="Color.Primary"
-                                     ValueChanged="@(OnShowPreviewChanged)" />
+                        <Switch T="bool"
+                                Value="_showPreviewPlugins"
+                                Label="Show preview plugins"
+                                Size="Size.Small"
+                                Color="Color.Primary"
+                                ValueChanged="@(OnShowPreviewChanged)" />
                     </MudStack>
                     @if (_availablePlugins is null || _availablePlugins.Count == 0)
                     {
@@ -264,15 +265,15 @@
     }
     
     
-    private void HandleTogglePlugin(PluginInfo plugin)
+    private async Task HandleTogglePlugin(PluginInfo plugin)
     {
         if (plugin.IsEnabled)
         {
-            PluginState.DisablePlugin(plugin.Manifest.Id);
+            await PluginState.DisablePluginAsync(plugin.Manifest.Id);
         }
         else
         {
-            PluginState.EnablePlugin(plugin.Manifest.Id);
+            await PluginState.EnablePluginAsync(plugin.Manifest.Id);
         }
     }
     
@@ -286,7 +287,7 @@
         
         if (result == true)
         {
-            PluginState.RemovePlugin(plugin.Manifest.Id);
+            await PluginState.RemovePluginAsync(plugin.Manifest.Id);
             UpdateAvailablePlugins();
             UpdateTabNames();
             StateHasChanged();
@@ -362,11 +363,11 @@
             {
                 try
                 {
-                    PluginState.RegisterPlugin(plugin);
+                    await PluginState.RegisterPluginAsync(plugin);
                 }
                 catch (InvalidOperationException)
                 {
-                    PluginState.RegisterOrUpgradePlugin(plugin);
+                    await PluginState.RegisterOrUpgradePluginAsync(plugin);
                 }
             }
             

--- a/Mythetech.Framework/Infrastructure/Plugins/Components/StandardPluginMenu.razor
+++ b/Mythetech.Framework/Infrastructure/Plugins/Components/StandardPluginMenu.razor
@@ -140,14 +140,14 @@
     {
         if (plugin.IsEnabled)
         {
-            PluginState.DisablePlugin(plugin.Manifest.Id);
+            await PluginState.DisablePluginAsync(plugin.Manifest.Id);
         }
         else
         {
-            PluginState.EnablePlugin(plugin.Manifest.Id);
+            await PluginState.EnablePluginAsync(plugin.Manifest.Id);
         }
     }
-    
+
     private async Task HandleDeletePlugin(PluginInfo plugin)
     {
         var result = await DialogService.ShowMessageBox(
@@ -155,10 +155,10 @@
             message: $"Are you sure you want to delete '{plugin.Manifest.Name}'? This action cannot be undone.",
             yesText: "Delete",
             cancelText: "Cancel");
-        
+
         if (result == true)
         {
-            PluginState.RemovePlugin(plugin.Manifest.Id);
+            await PluginState.RemovePluginAsync(plugin.Manifest.Id);
         }
     }
 
@@ -167,15 +167,15 @@
         var files = await FileOpenService.OpenFileAsync(
             title: "Select Plugin DLL",
             filters: [new FileFilter("Plugin DLLs", ["*.dll"])]);
-        
+
         if (files.Length == 0) return;
-        
+
         foreach (var dllPath in files)
         {
             var pluginInfo = PluginLoader.LoadPlugin(dllPath);
             if (pluginInfo is not null)
             {
-                PluginState.RegisterPlugin(pluginInfo);
+                await PluginState.RegisterPluginAsync(pluginInfo);
             }
         }
     }

--- a/docs/Infrastructure/Plugins/Lifecycle.md
+++ b/docs/Infrastructure/Plugins/Lifecycle.md
@@ -8,7 +8,7 @@ This document covers how plugins are loaded, enabled/disabled, and removed.
 
 ```csharp
 // Load all plugins from a directory
-app.Services.UsePlugins("plugins");
+await app.Services.UsePluginsAsync("plugins");
 ```
 
 **Discovery Process:**
@@ -34,7 +34,7 @@ plugins/
 
 ```csharp
 // Load from referenced assembly
-app.Services.UsePlugin(typeof(MyPlugin.Manifest).Assembly);
+await app.Services.UsePluginAsync(typeof(MyPlugin.Manifest).Assembly);
 ```
 
 WebAssembly doesn't support dynamic assembly loading, so plugins must be referenced at compile time.
@@ -129,7 +129,7 @@ public class PluginInfo
 
 ```csharp
 var pluginState = services.GetRequiredService<PluginState>();
-pluginState.EnablePlugin("com.example.myplugin");
+await pluginState.EnablePluginAsync("com.example.myplugin");
 ```
 
 **Flow:**
@@ -142,7 +142,7 @@ pluginState.EnablePlugin("com.example.myplugin");
 ### Disabling a Plugin
 
 ```csharp
-pluginState.DisablePlugin("com.example.myplugin");
+await pluginState.DisablePluginAsync("com.example.myplugin");
 ```
 
 **Flow:**
@@ -209,7 +209,7 @@ pluginState.PluginDisabling += (sender, args) =>
 ## Removing Plugins
 
 ```csharp
-pluginState.RemovePlugin("com.example.myplugin");
+await pluginState.RemovePluginAsync("com.example.myplugin");
 ```
 
 **Flow:**
@@ -239,7 +239,7 @@ The UI can prompt to delete stored data when removing the plugin.
 
 ```csharp
 // Registers or upgrades if newer version
-pluginState.RegisterOrUpgradePlugin(newPluginInfo);
+await pluginState.RegisterOrUpgradePluginAsync(newPluginInfo);
 ```
 
 **Behavior:**
@@ -324,25 +324,25 @@ Displays error message and optionally stack trace without crashing the host.
                     │ (Disabled)  │
                     └──────┬──────┘
                            │
-              PluginState.RegisterPlugin()
+              PluginState.RegisterPluginAsync()
                            │
                            ▼
                     ┌─────────────┐
-                    │  Registered │◄────────────────┐
-                    │  (Enabled)  │                 │
-                    └──────┬──────┘                 │
-                           │                        │
-         ┌─────────────────┼─────────────────┐      │
-         │                 │                 │      │
-    DisablePlugin()   StateChanged()    EnablePlugin()
-         │                 │                 │      │
-         ▼                 ▼                 ▼      │
-    ┌─────────────┐  ┌───────────┐    ┌───────────┐│
-    │  Disabled   │  │    UI     │    │  Enabled  ││
-    │(no messages)│  │  Updates  │    │(messages) │┘
+                    │  Registered │◄────────────────────┐
+                    │  (Enabled)  │                     │
+                    └──────┬──────┘                     │
+                           │                            │
+         ┌─────────────────┼─────────────────┐          │
+         │                 │                 │          │
+  DisablePluginAsync() StateChanged()  EnablePluginAsync()
+         │                 │                 │          │
+         ▼                 ▼                 ▼          │
+    ┌─────────────┐  ┌───────────┐    ┌───────────┐    │
+    │  Disabled   │  │    UI     │    │  Enabled  │────┘
+    │(no messages)│  │  Updates  │    │(messages) │
     └──────┬──────┘  └───────────┘    └───────────┘
            │
-     RemovePlugin()
+   RemovePluginAsync()
            │
            ▼
     ┌─────────────┐

--- a/samples/SampleHost.Desktop/MainLayout.razor
+++ b/samples/SampleHost.Desktop/MainLayout.razor
@@ -7,7 +7,6 @@
 @using SampleHost.Shared
 @using SampleHost.Shared.Settings
 @inherits LayoutComponentBase
-@inject IServiceProvider ServiceProvider
 @inject PluginState PluginState
 @inject IPluginAssetLoader AssetLoader
 @inject IShowFileService ShowFileService
@@ -100,7 +99,17 @@
     {
         try
         {
-            await ServiceProvider.UsePluginsFromSettingsAsync();
+            // Get custom plugin directory from settings if configured
+            var pluginSettings = SettingsProvider.GetSettings<PluginSettings>();
+            string? pluginDirectory = null;
+
+            if (!string.IsNullOrWhiteSpace(pluginSettings?.CustomPluginDirectory)
+                && Directory.Exists(pluginSettings.CustomPluginDirectory))
+            {
+                pluginDirectory = pluginSettings.CustomPluginDirectory;
+            }
+
+            await PluginState.InitializePluginsAsync(pluginDirectory);
             await PluginState.LoadStateAsync();
             await LoadAllPluginAssetsAsync();
         }

--- a/samples/SampleHost.Desktop/Pages/Index.razor
+++ b/samples/SampleHost.Desktop/Pages/Index.razor
@@ -99,11 +99,11 @@
 </MudGrid>
 
 @code {
-    private void TogglePlugin(string pluginId, bool enabled)
+    private async Task TogglePlugin(string pluginId, bool enabled)
     {
         if (enabled)
-            PluginState.EnablePlugin(pluginId);
+            await PluginState.EnablePluginAsync(pluginId);
         else
-            PluginState.DisablePlugin(pluginId);
+            await PluginState.DisablePluginAsync(pluginId);
     }
 }

--- a/samples/SampleHost.Desktop/Pages/PluginsPage.razor
+++ b/samples/SampleHost.Desktop/Pages/PluginsPage.razor
@@ -63,12 +63,12 @@ else
 }
 
 @code {
-    private void TogglePlugin(string pluginId, bool enabled)
+    private async Task TogglePlugin(string pluginId, bool enabled)
     {
         if (enabled)
-            PluginState.EnablePlugin(pluginId);
+            await PluginState.EnablePluginAsync(pluginId);
         else
-            PluginState.DisablePlugin(pluginId);
+            await PluginState.DisablePluginAsync(pluginId);
     }
 }
 

--- a/samples/SampleHost.Desktop/Program.cs
+++ b/samples/SampleHost.Desktop/Program.cs
@@ -56,6 +56,10 @@ class Program
         builder.Services.AddDesktopSettingsStorage("SampleHost");
         builder.Services.AddPluginStateProvider("SampleHost");
 
+        // Register settings from assemblies (new DI-friendly API)
+        builder.Services.RegisterSettingsFromAssembly(typeof(SampleAppSettings).Assembly);
+        builder.Services.RegisterSettingsFromAssembly(typeof(PluginSettings).Assembly);
+
         builder.RootComponents.Add<App>("app");
 
         var app = builder.Build();
@@ -65,9 +69,6 @@ class Program
         app.Services.UseMcp();
         app.Services.UsePluginFramework();
         app.Services.UseSettingsFramework();
-        app.Services.RegisterSettings<SampleAppSettings>();
-        app.Services.RegisterSettings<PluginSettings>();
-        app.Services.RegisterSettings<McpSettings>();
 
         // Plugin loading is deferred to MainLayout.OnAfterRenderAsync
         // This allows custom plugin directory setting to take effect

--- a/samples/SampleHost.WebAssembly/Pages/Index.razor
+++ b/samples/SampleHost.WebAssembly/Pages/Index.razor
@@ -104,12 +104,12 @@
 </MudGrid>
 
 @code {
-    private void TogglePlugin(string pluginId, bool enabled)
+    private async Task TogglePlugin(string pluginId, bool enabled)
     {
         if (enabled)
-            PluginState.EnablePlugin(pluginId);
+            await PluginState.EnablePluginAsync(pluginId);
         else
-            PluginState.DisablePlugin(pluginId);
+            await PluginState.DisablePluginAsync(pluginId);
     }
 }
 

--- a/samples/SampleHost.WebAssembly/Pages/PluginsPage.razor
+++ b/samples/SampleHost.WebAssembly/Pages/PluginsPage.razor
@@ -60,12 +60,12 @@ else
 }
 
 @code {
-    private void TogglePlugin(string pluginId, bool enabled)
+    private async Task TogglePlugin(string pluginId, bool enabled)
     {
         if (enabled)
-            PluginState.EnablePlugin(pluginId);
+            await PluginState.EnablePluginAsync(pluginId);
         else
-            PluginState.DisablePlugin(pluginId);
+            await PluginState.DisablePluginAsync(pluginId);
     }
 }
 

--- a/samples/SampleHost.WebAssembly/Program.cs
+++ b/samples/SampleHost.WebAssembly/Program.cs
@@ -28,18 +28,19 @@ builder.Services.AddSettingsFramework();
 builder.Services.AddWebAssemblySettingsStorage();
 builder.Services.AddPluginStateProvider();
 
+// Register settings from assemblies (new DI-friendly API)
+builder.Services.RegisterSettingsFromAssembly(typeof(SampleAppSettings).Assembly);
+builder.Services.RegisterSettingsFromAssembly(typeof(Mythetech.Framework.Infrastructure.Plugins.PluginSettings).Assembly);
+
 var host = builder.Build();
 
 host.Services.UseMessageBus();
 host.Services.UsePluginFramework();
 host.Services.UseSettingsFramework();
-host.Services.RegisterSettings<SampleAppSettings>();
-host.Services.RegisterSettings<PluginSettings>();
-host.Services.RegisterSettings<McpSettings>();
 
 // In WASM, we load the plugin from the referenced assembly directly
 // (dynamic DLL loading is not supported in browser WASM)
-host.Services.UsePlugin(typeof(SamplePlugin.SamplePluginManifest).Assembly);
+await host.Services.UsePluginAsync(typeof(SamplePlugin.SamplePluginManifest).Assembly);
 
 await host.RunAsync();
 


### PR DESCRIPTION
Consumers had already started doing this to defer work to after page load, i.e. `OnAfterRenderAsync` on the page

This more formalizes that pattern by explicitly letting the PluginState do this and also do deprecate the old `Use...` registration time methods

misc code cleanup/improvements